### PR TITLE
Added Windows compatibility to build and test scripts

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -28,7 +28,10 @@ val Error = 1 // 1 exit code
 
 PlayKeys.playRunHooks <+= baseDirectory.map(UIBuild.apply)
 
-def runScript(script: String)(implicit dir: File): Int = Process(script, dir) !
+val isWindows = System.getProperty("os.name").toLowerCase().contains("win")
+
+def runScript(script: String)(implicit dir: File): Int = {
+if(isWindows){ Process("cmd /c " + script, dir) } else { Process(script, dir) } }!
 
 def uiWasInstalled(implicit dir: File): Boolean = (dir / "node_modules").exists()
 

--- a/project/UIBuild.scala
+++ b/project/UIBuild.scala
@@ -9,13 +9,22 @@ object UIBuild {
 
       var process: Option[Process] = None
 
+      var npmInstall: String = "npm install"
+      var npmRun: String = "npm run build -- --watch"
+
+      // Windows requires npm commands prefixed with cmd /c
+      if (System.getProperty("os.name").toLowerCase().contains("win")){
+        npmInstall = "cmd /c" + npmInstall
+        npmRun = "cmd /c" + npmRun
+      }
+
       override def beforeStarted(): Unit = {
-        if (!(base / "ui" / "node_modules").exists()) Process("npm install", base / "ui").!
+        if (!(base / "ui" / "node_modules").exists()) Process(npmInstall, base / "ui").!
       }
 
       override def afterStarted(addr: InetSocketAddress): Unit = {
         process = Option(
-          Process("npm run build -- --watch", base / "ui").run
+          Process(npmRun, base / "ui").run
         )
       }
 

--- a/test/ProtractorSpec.scala
+++ b/test/ProtractorSpec.scala
@@ -25,7 +25,11 @@ class ProtractorSpec extends PlaySpec with OneServerPerSuite {
   }
 
   private def runProtractorTests(baseUrl: String): Int = {
-    Process(s"npm run play-e2e -- --baseUrl $baseUrl", app.getFile("ui"))
+    var runProtractor: String = "npm run play-e2e -- --baseUrl " + baseUrl
+    if (System.getProperty("os.name").toLowerCase().contains("win")){
+      runProtractor = "cmd /c " + runProtractor
+    }
+    Process(runProtractor, app.getFile("ui"))
       .run(pipingInputAndOutput)
       .exitValue()
   }


### PR DESCRIPTION
fixes #1 - allows `sbt run` and `sbt test` to work out-of-the-box on windows OS (tested on Windows 10 x64) and Mac  (tested on OSX El Capitan 10.11.6).

Still outstanding issues:
 * You get an error about the postinstall `chmod +x normalize_file_names.sh` command, because `chmod` doesn't exist on Windows. Not sure what to do about that, since you can't put OS-checking logic in package.json, could possibly have the postinstall script call some javascript with node that carries out OS-specific commands. This has no effect on the web app running successfully though. 
* `sbt test` fails initially with error code 135: `Could not find update-config.json. Run    'webdriver-manager update' to download binaries.` This might be related to [this angular-cli issue](https://github.com/angular/angular-cli/issues/4640). In any case, this is fixed by running `npm run pree2e` in the `/ui` folder. Maybe we could add that to the normal sbt test hook. 
